### PR TITLE
Fix updating registry records when installing.

### DIFF
--- a/news/15.bugfix
+++ b/news/15.bugfix
@@ -1,0 +1,4 @@
+Fix updating registry records when installing.
+Previously, our configuration changes could be gone after a restart.
+If your accordions don't work, you can deactivate and activate this add-on to fix it.
+@mauritsvanrees


### PR DESCRIPTION
Previously, our configuration changes could be gone after a restart. If your accordions don't work, you can deactivate and activate this add-on to fix it.

Fixes issue #15.