### PR TITLE
Do not require `plone.app.robotframework` for testing.

### DIFF
--- a/news/+norobot.tests
+++ b/news/+norobot.tests
@@ -1,0 +1,3 @@
+Do not require `plone.app.robotframework` for testing.
+We don't have robot tests.  This avoids running `rfbrowser init` on each test run.
+@mauritsvanrees

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
             "zestreleaser.towncrier",
             "zest.pocompile",
             "plone.app.testing",
-            "plone.app.robotframework",
             "pytest",
             "pytest-cov",
             "pytest-plone>=0.5.0",

--- a/src/collective/outputfilters/tinymceaccordion/testing.py
+++ b/src/collective/outputfilters/tinymceaccordion/testing.py
@@ -1,4 +1,3 @@
-from plone.app.robotframework.testing import REMOTE_LIBRARY_BUNDLE_FIXTURE
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
@@ -33,14 +32,4 @@ INTEGRATION_TESTING = IntegrationTesting(
 FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FIXTURE, WSGI_SERVER_FIXTURE),
     name="Collective.Outputfilters.TinymceaccordionLayer:FunctionalTesting",
-)
-
-
-ACCEPTANCE_TESTING = FunctionalTesting(
-    bases=(
-        FIXTURE,
-        REMOTE_LIBRARY_BUNDLE_FIXTURE,
-        WSGI_SERVER_FIXTURE,
-    ),
-    name="Collective.Outputfilters.TinymceaccordionLayer:AcceptanceTesting",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from collective.outputfilters.tinymceaccordion.testing import ACCEPTANCE_TESTING
 from collective.outputfilters.tinymceaccordion.testing import FUNCTIONAL_TESTING
 from collective.outputfilters.tinymceaccordion.testing import INTEGRATION_TESTING
 from pytest_plone import fixtures_factory
@@ -10,7 +9,6 @@ pytest_plugins = ["pytest_plone"]
 globals().update(
     fixtures_factory(
         (
-            (ACCEPTANCE_TESTING, "acceptance"),
             (FUNCTIONAL_TESTING, "functional"),
             (INTEGRATION_TESTING, "integration"),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -92,10 +92,8 @@ deps =
     pytest
     pytest-plone
 test =
-    rfbrowser init
     pytest --disable-warnings {posargs} {toxinidir}/tests
 coverage =
-    rfbrowser init
     coverage run --source collective.outputfilters.tinymceaccordion -m pytest  {posargs} --disable-warnings {toxinidir}/tests
     coverage report -m --format markdown
     coverage xml


### PR DESCRIPTION
We don't have robot tests.  This avoids running `rfbrowser init` on each test run.

I reconfigured with `plone.meta` after this change, and this indeed automatically removed the `rfbrowser init` lines from `tox.ini`.